### PR TITLE
Add transform subcommand to restore on a different host

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and ready in the event the secondary master needs to take over service from the
 primary.
 
 
-## Transformation (TODO)
+## Transformation
 
 To achieve the goal of replicating node classification groups from one PE
 monolithic master to a secondary monolithic master, certain values need to be
@@ -36,8 +36,20 @@ To illustrate, consider the PuppetDB classification group:
       }
     }
 
-This group will need to have `"master1.puppet.vm"` transformed to
-`"master2.puppet.vm"` when imported for replication purposes.
+Transformation from master1 to master2 is possible:
+
+    export PATH="/opt/pupeptlabs/puppet/bin:$PATH"
+    ncio --uri https://master1.puppet.vm:4433/classification-api/v1 backup \
+     | ncio transform --hostname master1.puppet.vm:master2.puppet.vm \
+     | ncio --uri https://master2.puppet.vm:4433/classification-api/v1 restore
+
+This method of "replicating" node classification data has some caveats.  It's
+only been tested on PE Monolithic masters.  The method assumes master1 and
+master2 share the same Certificate Authority.  By default, only the default
+`puppet_enterprise` classification groups are transformed.
+
+Additional groups and classes may be processed by chaining transfomation
+processes and getting creative with the use of the `--class-matcher` option.
 
 ## Installation
 

--- a/lib/ncio/support/transform.rb
+++ b/lib/ncio/support/transform.rb
@@ -1,0 +1,73 @@
+module Ncio
+  module Support
+    ##
+    # Helper methods for transforming a backup data structure.  The
+    # transformation methods match groups against class names.  If there's a
+    # match, the rules and the matching class paramter values are transformed,
+    # mapping one hostname to another.
+    module Transform
+      def group_matches?(group)
+        classes = group['classes'].keys
+        name = classes.find { |class_name| class_matches?(class_name) }
+        msg = name ? 'Matched' : 'Did not match'
+        debug(msg + " group: #{group['name']}, classes: #{JSON.dump(classes)}")
+        name ? true : false
+      end
+
+      def class_matches?(class_name)
+        opts[:matcher].match(class_name)
+      end
+
+      ##
+      # @param [Hash] group
+      def transform_group(group)
+        # Transform rules if they're present in the 'rule' key
+        group['rule'] = transform_rules(group['rule']) if group['rule']
+        # Transform class parameters if there are classes with parameters
+        classes = group['classes']
+        group['classes'] = classes.each_with_object({}) do |(name, params), hsh|
+          hsh[name] = if class_matches?(name) then transform_params(params)
+                      else params
+                      end
+          hsh
+        end
+        # Return the updated group
+        group
+      end
+
+      ##
+      # Recursively transform an array of rules
+      #
+      # @param [Array] rules Array of rule objects.  See the [Rule
+      #   Grammar](https://goo.gl/6BNc6D)
+      #
+      # @return [Array] transformed rules
+      def transform_rules(rules)
+        rules.map do |rule|
+          case rule
+          when Array
+            transform_rules(rule)
+          when String
+            opts[:hostname_map][rule]
+          end
+        end
+      end
+
+      ##
+      # Transform class parameters, which are a simple key / value JSON hash.
+      # The values of each hash are routed through the hostname "smart map"
+      #
+      # @return [Hash<String, String>] transformed parameter hash map
+      def transform_params(params)
+        params.each_with_object({}) do |(key, val), hsh|
+          hsh[key] = case val
+                     when Array then val.map { |v| opts[:hostname_map][v] }
+                     when String then opts[:hostname_map][val]
+                     else val
+                     end
+          hsh
+        end
+      end
+    end
+  end
+end

--- a/spec/fixtures/backup.json
+++ b/spec/fixtures/backup.json
@@ -62,7 +62,7 @@
       [
         "=",
         "name",
-        "master1.puppet.vm"
+        "master2.puppet.vm"
       ]
     ],
     "variables": {
@@ -83,7 +83,7 @@
       [
         "=",
         "name",
-        "master1.puppet.vm"
+        "master2.puppet.vm"
       ]
     ],
     "variables": {
@@ -104,7 +104,7 @@
       [
         "=",
         "name",
-        "master1.puppet.vm"
+        "master2.puppet.vm"
       ]
     ],
     "variables": {
@@ -144,7 +144,7 @@
       [
         "=",
         "name",
-        "master1.puppet.vm"
+        "master2.puppet.vm"
       ]
     ],
     "variables": {
@@ -189,7 +189,7 @@
       [
         "=",
         "name",
-        "master1.puppet.vm"
+        "master2.puppet.vm"
       ]
     ],
     "variables": {
@@ -220,21 +220,21 @@
     "classes": {
       "puppet_enterprise": {
         "mcollective_middleware_hosts": [
-          "master1.puppet.vm"
+          "master2.puppet.vm"
         ],
         "use_application_services": true,
-        "database_host": "master1.puppet.vm",
-        "puppetdb_host": "master1.puppet.vm",
+        "database_host": "master2.puppet.vm",
+        "puppetdb_host": "master2.puppet.vm",
         "database_port": "5432",
         "database_ssl": true,
-        "puppet_master_host": "master1.puppet.vm",
-        "certificate_authority_host": "master1.puppet.vm",
+        "puppet_master_host": "master2.puppet.vm",
+        "certificate_authority_host": "master2.puppet.vm",
         "console_port": "443",
         "puppetdb_database_name": "pe-puppetdb",
         "puppetdb_database_user": "pe-puppetdb",
-        "pcp_broker_host": "master1.puppet.vm",
+        "pcp_broker_host": "master2.puppet.vm",
         "puppetdb_port": "8081",
-        "console_host": "master1.puppet.vm"
+        "console_host": "master2.puppet.vm"
       }
     }
   },
@@ -247,7 +247,7 @@
       [
         "=",
         "name",
-        "master1.puppet.vm"
+        "master2.puppet.vm"
       ]
     ],
     "variables": {


### PR DESCRIPTION
Without this patch it is not possible to restore a backup taken on another host.
This patch addresses the problem by transforming the backup data in the
following manner.  Node groups having class names that match the `--class-matcher`
command line option (A string passed to Regexp.new) are processed.  The value of
the `'rule'` key is recursively transformed, replacing all instances of the
specified hostnames.  Additionally, the class parameter values are
(non-recursively) transformed.

Transformation is fairly naive.  Literal string matches are replaced, no regular
expression or substring matching is performed on the hostname replacement.
