### PR TITLE
Log backups and restores to syslog daemon facility

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,33 @@ white-list of certificates is located at
       backup > /var/tmp/backup.json
     I, [2016-06-28T19:28:48.236257 #3148]  INFO -- : Backup completed successfully!
 
+## Logging
+
+The status of backup and restore operations are logged to the syslog by default.
+The `daemon` facility is used to ensure messages are written to files on a wide
+variety of systems that log daemon messages by default.  A general exception
+handler will log a backtrace in JSON format to help log processors and
+notification systems like Splunk and Logstash.
+
+Here's an example of a failed restore triggering the catch all handler:
+
+    Jun 29 12:12:21 Jeff-McCune ncio[51474]: ERROR Restoring backup: {
+      "error": "RuntimeError",
+      "message": "Some random error",
+      "backtrace": [
+        "/Users/jeff/projects/puppet/ncio/lib/ncio/app.rb:94:in `restore_groups'",
+        "/Users/jeff/projects/puppet/ncio/lib/ncio/app.rb:59:in `run'",
+        "/Users/jeff/projects/puppet/ncio/exe/ncio:5:in `<top (required)>'"
+      ]
+    }
+
+Log to the console using the `--no-syslog` command line option.
+
+    ncio --no-syslog restore --file backup.json
+
+The tool can only log to either syslog or the console at this time.  Multiple
+log destinations are not currently supported.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at

--- a/lib/ncio/support/option_parsing.rb
+++ b/lib/ncio/support/option_parsing.rb
@@ -1,4 +1,6 @@
 require 'ncio/version'
+require 'socket'
+
 # rubocop:disable Metrics/ModuleLength
 module Ncio
   module Support
@@ -70,7 +72,9 @@ module Ncio
           log_msg = 'Log file to write to or keywords '\
             'STDOUT, STDERR {NCIO_LOGTO}'
           opt :logto, log_msg, default: env['NCIO_LOGTO'] || 'STDERR'
-          opt :debug
+          opt :syslog, 'Log to syslog', default: true, conflicts: :logto
+          opt :verbose, 'Set log level to INFO'
+          opt :debug, 'Set log level to DEBUG'
         end
       end
       # rubocop:enable Metrics/MethodLength, Metrics/AbcSize


### PR DESCRIPTION
Without this patch there is no logging to syslog.  This is a problem because
backup and restore operations need to be monitored.  If not, people may lose
sleep wondering if the backup is successful or not.

This patch addresses the problem by logging to the syslog daemon facility by
default.  The result of the backup and the restore are logged at level "notice"
which is enabled by default in most logging configurations.  The goal is make
sure the result is written to the system log and tools like Splunk or Logstash
can easily keep an eye on the result.

Catch-all exception handlers are also added to the backup and restore task.
This allows log messages to be written in the event of any unforeseen errors.
