### PR TITLE
fixes #8

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Install this tool on the same node running the node classification service:
 
 ## Usage
 
-If the file `/etc/puppetlabs/puppet/ssl/certs/pe-internal-orchestrator.pem`
-exists on the same node as the Node Classifier, then no configuration is
-necessary.  The default options will work to backup and restore node
-classification data.
+Ncio will attempt to use the host certificate from 
+`/etc/puppetlabs/puppet/ssl/certs/$FQDN.pem` if it exists on the same node as
+the Node Classifier.  If this certificate has sufficient access then no 
+configuration is necessary.  The default options will work to backup and 
+restore node classification data.
 
     sudo -H -u pe-puppet /opt/puppetlabs/puppet/bin/ncio backup > /var/tmp/backup.json
     I, [2016-06-28T19:25:55.507684 #2992]  INFO -- : Backup completed successfully!

--- a/lib/ncio/http_client.rb
+++ b/lib/ncio/http_client.rb
@@ -27,8 +27,8 @@ module Ncio
       host: Socket.gethostname,
       port: 4433,
       use_ssl: true,
-      cert: ssldir + '/certs/pe-internal-orchestrator.pem',
-      key: ssldir + '/private_keys/pe-internal-orchestrator.pem',
+      cert: "#{ssldir}/certs/#{Socket.gethostname}.pem",
+      key: "#{ssldir}/private_keys/#{Socket.gethostname}.pem",
       cacert: ssldir + '/certs/ca.pem'
     }.freeze
 
@@ -44,11 +44,11 @@ module Ncio
     #
     # @option opts [String] :cert The path to the PEM encoded client
     #   certificate.  Defaults to
-    #   `"/etc/puppetlabs/puppet/ssl/certs/pe-internal-orchestrator.pem"`
+    #   `"/etc/puppetlabs/puppet/ssl/certs/$FQDN.pem"`
     #
     # @option opts [String] :key The path to the PEM encoded RSA private key
     #   used for the SSL client connection.  Defaults to
-    #   `"/etc/puppetlabs/puppet/ssl/private_keys/pe-internal-orchestrator.pem"`
+    #   `"/etc/puppetlabs/puppet/ssl/private_keys/$FQDN.pem"`
     #
     # @option opts [String] :cacert The path to the PEM encoded CA certificate
     #   used to authenticate the service URL.  Defaults to

--- a/lib/ncio/support/option_parsing.rb
+++ b/lib/ncio/support/option_parsing.rb
@@ -190,15 +190,17 @@ Transformation:
 Global options: (Note, command line arguments supersede ENV vars in {}'s)
       EOBANNER
 
+      hostname = Socket.gethostname.downcase
+
       SSLDIR = '/etc/puppetlabs/puppet/ssl'.freeze
       CERT_MSG = 'White listed client SSL cert {NCIO_CERT} '\
         'See: https://goo.gl/zCjncC'.freeze
       CERT_DEFAULT = (SSLDIR + '/certs/'\
-                      'pe-internal-orchestrator.pem').freeze
+                      + hostname + '.pem').freeze
       KEY_MSG = 'Client RSA key, must match certificate '\
         '{NCIO_KEY}'.freeze
       KEY_DEFAULT = (SSLDIR + '/private_keys/'\
-                     'pe-internal-orchestrator.pem').freeze
+                     + hostname + '.pem').freeze
       CACERT_MSG = 'CA Cert to authenticate the service uri '\
         '{NCIO_CACERT}'.freeze
       CACERT_DEFAULT = (SSLDIR + '/certs/ca.pem').freeze

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -22,12 +22,12 @@ describe 'Ncio::HttpClient' do
         expect(subject.use_ssl).to be(true)
       end
 
-      cert = "#{ssldir}/certs/pe-internal-orchestrator.pem"
+      cert = "#{ssldir}/certs/#{Socket.gethostname}.pem"
       it "sets cert to #{cert}" do
         expect(subject.cert).to eq(cert)
       end
 
-      key = "#{ssldir}/private_keys/pe-internal-orchestrator.pem"
+      key = "#{ssldir}/private_keys/#{Socket.gethostname}.pem"
       it "sets key to #{key}" do
         expect(subject.key).to eq(key)
       end


### PR DESCRIPTION
Puppet Enterprise 2016.4.0 removes the pe-internal-orchestrator.pem certificate which ncio previously relied on.

On a fresh install of Puppet Enterprise on a host called `puppet.demo.internal`, only the following certificates are now present at time of install:

```shell
[root@puppet ncio]# ls /etc/puppetlabs/puppet/ssl/private_keys/
pe-internal-mcollective-servers.pem         
pe-internal-puppet-console-mcollective-client.pem
pe-internal-peadmin-mcollective-client.pem  
puppet.demo.internal.pem
```

Of these files, the certificate incorporating the hostname will have access to the node classifier as this is a Puppet Enterprise master.

This PR updates the code to use this new naming convention 