### PR TITLE
Add backwards compatible default certificate behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,11 @@ Install this tool on the same node running the node classification service:
 
 ## Usage
 
-If the file `/etc/puppetlabs/puppet/ssl/certs/pe-internal-orchestrator.pem`
-exists on the same node as the Node Classifier, then no configuration is
-necessary.  The default options will work to backup and restore node
-classification data.
+Ncio will attempt to use the host certificate from 
+`/etc/puppetlabs/puppet/ssl/certs/$FQDN.pem` if it exists on the same node as
+the Node Classifier.  If this certificate has sufficient access then no 
+configuration is necessary.  The default options will work to backup and 
+restore node classification data.
 
     sudo -H -u pe-puppet /opt/puppetlabs/puppet/bin/ncio backup > /var/tmp/backup.json
     I, [2016-06-28T19:25:55.507684 #2992]  INFO -- : Backup completed successfully!

--- a/lib/ncio/http_client.rb
+++ b/lib/ncio/http_client.rb
@@ -27,8 +27,8 @@ module Ncio
       host: Socket.gethostname,
       port: 4433,
       use_ssl: true,
-      cert: ssldir + '/certs/pe-internal-orchestrator.pem',
-      key: ssldir + '/private_keys/pe-internal-orchestrator.pem',
+      cert: "#{ssldir}/certs/#{Socket.gethostname}.pem",
+      key: "#{ssldir}/private_keys/#{Socket.gethostname}.pem",
       cacert: ssldir + '/certs/ca.pem'
     }.freeze
 
@@ -44,11 +44,11 @@ module Ncio
     #
     # @option opts [String] :cert The path to the PEM encoded client
     #   certificate.  Defaults to
-    #   `"/etc/puppetlabs/puppet/ssl/certs/pe-internal-orchestrator.pem"`
+    #   `"/etc/puppetlabs/puppet/ssl/certs/$FQDN.pem"`
     #
     # @option opts [String] :key The path to the PEM encoded RSA private key
     #   used for the SSL client connection.  Defaults to
-    #   `"/etc/puppetlabs/puppet/ssl/private_keys/pe-internal-orchestrator.pem"`
+    #   `"/etc/puppetlabs/puppet/ssl/private_keys/$FQDN.pem"`
     #
     # @option opts [String] :cacert The path to the PEM encoded CA certificate
     #   used to authenticate the service URL.  Defaults to

--- a/lib/ncio/support/option_parsing.rb
+++ b/lib/ncio/support/option_parsing.rb
@@ -59,6 +59,8 @@ module Ncio
       def parse_global_options!(argv, env)
         semver = Ncio::VERSION
         host = Socket.gethostname
+        cert_default = self.cert_default
+        key_default  = self.key_default
         Ncio::Trollop.options(argv) do
           stop_on_unknown
           version "ncio #{semver} (c) 2016 Jeff McCune"
@@ -66,8 +68,8 @@ module Ncio
           uri_dfl = env['NCIO_URI'] || "https://#{host}:4433/classifier-api/v1"
           opt :uri, 'Node Classifier service uri '\
             '{NCIO_URI}', default: uri_dfl
-          opt :cert, CERT_MSG, default: env['NCIO_CERT'] || CERT_DEFAULT
-          opt :key, KEY_MSG, default: env['NCIO_KEY'] || KEY_DEFAULT
+          opt :cert, CERT_MSG, default: env['NCIO_CERT'] || cert_default
+          opt :key, KEY_MSG, default: env['NCIO_KEY'] || key_default
           opt :cacert, CACERT_MSG, default: env['NCIO_CACERT'] || CACERT_DEFAULT
           log_msg = 'Log file to write to or keywords '\
             'STDOUT, STDERR {NCIO_LOGTO}'
@@ -167,6 +169,22 @@ module Ncio
         end
       end
 
+      def self.pem_exists?(name)
+        File.exist?(SSLDIR + "/certs/#{name}.pem")
+      end
+
+      def certname
+        NAMES.find { |n| Ncio::Support::OptionParsing.pem_exists?(n) } || NAMES.last
+      end
+
+      def cert_default
+        SSLDIR + "/certs/#{certname}.pem"
+      end
+
+      def key_default
+        SSLDIR + "/private_keys/#{certname}.pem"
+      end
+
       BANNER = <<-'EOBANNER'.freeze
 usage: ncio [GLOBAL OPTIONS] SUBCOMMAND [ARGS]
 Sub Commands:
@@ -190,17 +208,15 @@ Transformation:
 Global options: (Note, command line arguments supersede ENV vars in {}'s)
       EOBANNER
 
-      hostname = Socket.gethostname.downcase
+      # Names used to look for the default client certificate
+      NAMES = ['pe-internal-orchestrator', Socket.gethostname.downcase]
 
       SSLDIR = '/etc/puppetlabs/puppet/ssl'.freeze
+
       CERT_MSG = 'White listed client SSL cert {NCIO_CERT} '\
         'See: https://goo.gl/zCjncC'.freeze
-      CERT_DEFAULT = (SSLDIR + '/certs/'\
-                      + hostname + '.pem').freeze
       KEY_MSG = 'Client RSA key, must match certificate '\
         '{NCIO_KEY}'.freeze
-      KEY_DEFAULT = (SSLDIR + '/private_keys/'\
-                     + hostname + '.pem').freeze
       CACERT_MSG = 'CA Cert to authenticate the service uri '\
         '{NCIO_CACERT}'.freeze
       CACERT_DEFAULT = (SSLDIR + '/certs/ca.pem').freeze

--- a/lib/ncio/support/option_parsing.rb
+++ b/lib/ncio/support/option_parsing.rb
@@ -190,15 +190,17 @@ Transformation:
 Global options: (Note, command line arguments supersede ENV vars in {}'s)
       EOBANNER
 
+      hostname = Socket.gethostname.downcase
+
       SSLDIR = '/etc/puppetlabs/puppet/ssl'.freeze
       CERT_MSG = 'White listed client SSL cert {NCIO_CERT} '\
         'See: https://goo.gl/zCjncC'.freeze
       CERT_DEFAULT = (SSLDIR + '/certs/'\
-                      'pe-internal-orchestrator.pem').freeze
+                      + hostname + '.pem').freeze
       KEY_MSG = 'Client RSA key, must match certificate '\
         '{NCIO_KEY}'.freeze
       KEY_DEFAULT = (SSLDIR + '/private_keys/'\
-                     'pe-internal-orchestrator.pem').freeze
+                     + hostname + '.pem').freeze
       CACERT_MSG = 'CA Cert to authenticate the service uri '\
         '{NCIO_CACERT}'.freeze
       CACERT_DEFAULT = (SSLDIR + '/certs/ca.pem').freeze

--- a/spec/app_spec.rb
+++ b/spec/app_spec.rb
@@ -46,4 +46,47 @@ describe Ncio::App do
       expect(subject.version).to eq(Ncio::VERSION)
     end
   end
+
+  describe 'Default certificate' do
+    context 'pe-internal-orchestrator cert exists' do
+      before :each do
+        allow(Ncio::Support::OptionParsing).
+          to receive(:pem_exists?).
+          and_return(false)
+        expect(Ncio::Support::OptionParsing).
+          to receive(:pem_exists?).
+          with('pe-internal-orchestrator').
+          and_return(true, true)
+      end
+
+      it 'cert is pe-internal-orchestrator' do
+        expect(subject.opts[:cert]).to eq '/etc/puppetlabs/puppet/ssl/certs/pe-internal-orchestrator.pem'
+      end
+      it 'key is pe-internal-orchestrator' do
+        expect(subject.opts[:key]).to eq '/etc/puppetlabs/puppet/ssl/private_keys/pe-internal-orchestrator.pem'
+      end
+    end
+
+    context 'pe-internal-orchestrator cert does not exist' do
+      before :each do
+        allow(Ncio::Support::OptionParsing).
+          to receive(:pem_exists?).
+          and_return(false)
+        expect(Ncio::Support::OptionParsing).
+          to receive(:pem_exists?).
+          with('pe-internal-orchestrator').
+          and_return(false, false)
+      end
+      let :name do
+        Socket.gethostname.downcase
+      end
+
+      it 'cert is pe-internal-orchestrator' do
+        expect(subject.opts[:cert]).to eq "/etc/puppetlabs/puppet/ssl/certs/#{name}.pem"
+      end
+      it 'key is pe-internal-orchestrator' do
+        expect(subject.opts[:key]).to eq "/etc/puppetlabs/puppet/ssl/private_keys/#{name}.pem"
+      end
+    end
+  end
 end

--- a/spec/http_client_spec.rb
+++ b/spec/http_client_spec.rb
@@ -22,12 +22,12 @@ describe 'Ncio::HttpClient' do
         expect(subject.use_ssl).to be(true)
       end
 
-      cert = "#{ssldir}/certs/pe-internal-orchestrator.pem"
+      cert = "#{ssldir}/certs/#{Socket.gethostname}.pem"
       it "sets cert to #{cert}" do
         expect(subject.cert).to eq(cert)
       end
 
-      key = "#{ssldir}/private_keys/pe-internal-orchestrator.pem"
+      key = "#{ssldir}/private_keys/#{Socket.gethostname}.pem"
       it "sets key to #{key}" do
         expect(subject.key).to eq(key)
       end


### PR DESCRIPTION
Without this patch the default certificate used isn't backwards compatible with
previous versions of ncio.  This patch makes the behavior of how the default
certificate is handled backwards compatible with previous versions.

If the pe-internal-orchestrator certificate exists, it will be used as the
default.  If it does not exist, then the FQDN certificate will be used as the
default.

fixes #8