### PR TITLE
removed chunked encoding to prevent hanging (addresses #13)

### DIFF
--- a/lib/ncio/api/v1.rb
+++ b/lib/ncio/api/v1.rb
@@ -23,7 +23,6 @@ module Ncio
 
       DEFAULT_HEADERS = {
         'Content-Type' => 'application/json',
-        'Transfer-Encoding' => 'chunked'
       }.freeze
 
       ##


### PR DESCRIPTION
Verified that #13 happens in regular VMs (centos7, firewall off) as well as docker containers. This PR disables chunked encoding which prevents hanging observed 100% of time with modern versions of Puppet Enterprise.

Impact of disabling chunked encoding unclear due to immediate hanging without the fix