### PR TITLE
Remove chunked encoding for non-import requests

### DIFF
--- a/lib/ncio/api/v1.rb
+++ b/lib/ncio/api/v1.rb
@@ -23,7 +23,6 @@ module Ncio
 
       DEFAULT_HEADERS = {
         'Content-Type' => 'application/json',
-        'Transfer-Encoding' => 'chunked'
       }.freeze
 
       ##
@@ -130,6 +129,7 @@ module Ncio
       def import_hierarchy(stream)
         uri = build_uri('import-hierarchy')
         req = Net::HTTP::Post.new(uri, DEFAULT_HEADERS)
+        req['Transfer-Encoding'] = ['chunked']
         req.body_stream = stream
         resp = request(req)
         return true if resp.code == '204'


### PR DESCRIPTION
On versions of PE > 2017.2 GET requests with a `Transfer-Encoding: chunked` header cause the connection to hang. Chunked encoding doesn't really make sense for a GET request anyway so it's been moved to only affect imports.